### PR TITLE
Temporarily switch documentation to develop

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "epi-project/brane"
+          ref: develop
           path: code
 
       - name: Build code documentation


### PR DESCRIPTION
We don't have a version published right now, and I think develop is the only version that is going to compile as of now.

Okay, so the problem is that https://github.com/epi-project/brane/commit/96b1ce498c7027919aaa87bfe455d23c10d364ce has not been merged into master yet, so master does not build since the recent rust/cargo version. Bit of an unfortunate timing, but this will temporarilly fix it.

I also created and issue (https://github.com/epi-project/brane/issues/94) about the overal git structure we are using so that I can keep things up to date accordingly.