### PR TITLE
Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # Ignore automatically generated higlight.js files
 highlight.js.custom
+
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: all
+all: build build/user-guide build/specification build/tutorials
+
+.PHONY: build
+build:
+	mdbook build main
+	cp -r main/book build
+
+.PHONY: build/user-guide
+build/user-guide:
+	mdbook build user-guide
+	cp -r user-guide/book build/user-guide
+
+.PHONY: build/specification
+build/specification:
+	mdbook build specification
+	cp -r specification/book build/specification
+
+
+.PHONY: build/tutorials
+build/tutorials:
+	mdbook build tutorials
+	cp -r tutorials/book build/tutorials
+
+.PHONY: clean
+clean:
+	rm -r build

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: build build/user-guide build/specification build/tutorials
 
 .PHONY: build
-build:
+build: clean
 	mdbook build main
 	cp -r main/book build
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ build/tutorials:
 	mdbook build tutorials
 	cp -r tutorials/book build/tutorials
 
+.PHONY: serve
+serve:
+	python3 -m http.server -d build
+
 .PHONY: clean
 clean:
 	rm -r build

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ $ cd <book_dir>
 # Build using mdbook
 $ mdbook build
 ```
+
+Alternatively, you can use the provided Make file to compile the various books, or the documentation as a whole.
+```bash
+$ make all # To build the entire documentation
+
+$ make build/user-guide # To build user-guide
+$ make build/specification # To build specification
+$ make build/tutorials # To build tutorials
+
+```
+Note that this does not compile the code documentation as it will have to
+fetch the Brane source code and compile the documentation, which is almost
+always excessive. It is recommeneded that one compiles the documentation instead
+when developing the relevant parts of Brane.


### PR DESCRIPTION
The GitHub workflow could be executed using something like [act](https://github.com/nektos/act), but it is easier just to create a separate makefile.

Unfortunately, due to spaces in some filenames we cannot really use the requirements properly so all targets need to be PHONY.